### PR TITLE
fix: location routes with null parameters

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -24,15 +24,30 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
 
   override fun parseWriteRecord(records: ReadableArray): List<ExerciseSessionRecord> {
     return records.toMapList().map {
-      val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample ->
-        ExerciseRoute.Location(
+      val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample -> {
+        val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
+        val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
+        val altitude = getLengthFromJsMap(sample.getMap("altitude"))
+        val location = ExerciseRoute.Location(
           time = Instant.parse(sample.getString("time")),
           latitude = sample.getDouble("latitude"),
           longitude = sample.getDouble("longitude"),
-          horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy")),
-          verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy")),
-          altitude = getLengthFromJsMap(sample.getMap("altitude")),
         )
+
+        if (horizontalAccuracy != null) {
+          location = location.setHorizontalAccuracy(horizontalAccuracy)
+        }
+
+        if (verticalAccuracy != null) {
+          location = location.setVerticalAccuracy(verticalAccuracy)
+        }
+
+        if (altitude != null) {
+          location = location.setAltitude(altitude)
+        }
+
+        return@map location
+      }
       } ?: emptyList()
 
       ExerciseSessionRecord(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -25,28 +25,14 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
   override fun parseWriteRecord(records: ReadableArray): List<ExerciseSessionRecord> {
     return records.toMapList().map {
       val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample ->
-          var location = ExerciseRoute.Location(
+          ExerciseRoute.Location(
             time = Instant.parse(sample.getString("time")),
             latitude = sample.getDouble("latitude"),
             longitude = sample.getDouble("longitude"),
+            horizontalAccuracy = sample.getMap("horizontalAccuracy")?.let { getLengthFromJsMap(it) },
+            verticalAccuracy = sample.getMap("verticalAccuracy")?.let { getLengthFromJsMap(it) },
+            altitude = sample.getMap("altitude")?.let { getLengthFromJsMap(it) },
           )
-
-          if (sample.getMap("horizontalAccuracy") != null) {
-            val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
-            location = location.setHorizontalAccuracy(horizontalAccuracy)
-          }
-
-          if (sample.getMap("verticalAccuracy") != null) {
-            val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
-            location = location.setVerticalAccuracy(verticalAccuracy)
-          }
-
-          if (sample.getMap("altitude") != null) {
-            val altitude = getLengthFromJsMap(sample.getMap("altitude"))
-            location = location.setAltitude(altitude)
-          }
-
-          location
       } ?: emptyList()
 
       ExerciseSessionRecord(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -25,14 +25,14 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
   override fun parseWriteRecord(records: ReadableArray): List<ExerciseSessionRecord> {
     return records.toMapList().map {
       val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample ->
-          ExerciseRoute.Location(
-            time = Instant.parse(sample.getString("time")),
-            latitude = sample.getDouble("latitude"),
-            longitude = sample.getDouble("longitude"),
-            horizontalAccuracy = sample.getMap("horizontalAccuracy")?.let { getLengthFromJsMap(it) },
-            verticalAccuracy = sample.getMap("verticalAccuracy")?.let { getLengthFromJsMap(it) },
-            altitude = sample.getMap("altitude")?.let { getLengthFromJsMap(it) },
-          )
+        ExerciseRoute.Location(
+          time = Instant.parse(sample.getString("time")),
+          latitude = sample.getDouble("latitude"),
+          longitude = sample.getDouble("longitude"),
+          horizontalAccuracy = sample.getMap("horizontalAccuracy")?.let { getLengthFromJsMap(it) },
+          verticalAccuracy = sample.getMap("verticalAccuracy")?.let { getLengthFromJsMap(it) },
+          altitude = sample.getMap("altitude")?.let { getLengthFromJsMap(it) },
+        )
       } ?: emptyList()
 
       ExerciseSessionRecord(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -24,30 +24,29 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
 
   override fun parseWriteRecord(records: ReadableArray): List<ExerciseSessionRecord> {
     return records.toMapList().map {
-      val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample -> {
-          val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
-          val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
-          val altitude = getLengthFromJsMap(sample.getMap("altitude"))
-          val location = ExerciseRoute.Location(
+      val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample ->
+          var location = ExerciseRoute.Location(
             time = Instant.parse(sample.getString("time")),
             latitude = sample.getDouble("latitude"),
             longitude = sample.getDouble("longitude"),
           )
 
-          if (horizontalAccuracy != null) {
+          if (sample.getMap("horizontalAccuracy") != null) {
+            val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
             location = location.setHorizontalAccuracy(horizontalAccuracy)
           }
 
-          if (verticalAccuracy != null) {
+          if (sample.getMap("verticalAccuracy") != null) {
+            val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
             location = location.setVerticalAccuracy(verticalAccuracy)
           }
 
-          if (altitude != null) {
+          if (sample.getMap("altitude") != null) {
+            val altitude = getLengthFromJsMap(sample.getMap("altitude"))
             location = location.setAltitude(altitude)
           }
 
-          return@map location
-        }
+          location
       } ?: emptyList()
 
       ExerciseSessionRecord(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -25,29 +25,29 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
   override fun parseWriteRecord(records: ReadableArray): List<ExerciseSessionRecord> {
     return records.toMapList().map {
       val routeList = it.getMap("exerciseRoute")?.getArray("route")?.toMapList()?.map { sample -> {
-        val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
-        val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
-        val altitude = getLengthFromJsMap(sample.getMap("altitude"))
-        val location = ExerciseRoute.Location(
-          time = Instant.parse(sample.getString("time")),
-          latitude = sample.getDouble("latitude"),
-          longitude = sample.getDouble("longitude"),
-        )
+          val horizontalAccuracy = getLengthFromJsMap(sample.getMap("horizontalAccuracy"))
+          val verticalAccuracy = getLengthFromJsMap(sample.getMap("verticalAccuracy"))
+          val altitude = getLengthFromJsMap(sample.getMap("altitude"))
+          val location = ExerciseRoute.Location(
+            time = Instant.parse(sample.getString("time")),
+            latitude = sample.getDouble("latitude"),
+            longitude = sample.getDouble("longitude"),
+          )
 
-        if (horizontalAccuracy != null) {
-          location = location.setHorizontalAccuracy(horizontalAccuracy)
+          if (horizontalAccuracy != null) {
+            location = location.setHorizontalAccuracy(horizontalAccuracy)
+          }
+
+          if (verticalAccuracy != null) {
+            location = location.setVerticalAccuracy(verticalAccuracy)
+          }
+
+          if (altitude != null) {
+            location = location.setAltitude(altitude)
+          }
+
+          return@map location
         }
-
-        if (verticalAccuracy != null) {
-          location = location.setVerticalAccuracy(verticalAccuracy)
-        }
-
-        if (altitude != null) {
-          location = location.setAltitude(altitude)
-        }
-
-        return@map location
-      }
       } ?: emptyList()
 
       ExerciseSessionRecord(


### PR DESCRIPTION
The problem here is the `getLengthFromJsMap` function throws an error when null. Problem here is the fields are optional in the typings and the Kotlin class.

So I've added in some optionality checks here.